### PR TITLE
updated setColors function to parse int

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -54,9 +54,11 @@ setColors = () => {
   const timeBlocks = $('.hour')
 
   for (let i = 0; i < timeBlocks.length; i++) {
-    console.log(timeBlocks[i].innerHTML);
-    //   if (day.js().$H > timeBlock[i]) {
-    //     console.log(i.innerHTML);
+    let timeText =timeBlocks[i].innerHTML;
+    let timeInt = parseInt(timeText)
+    console.log(timeInt)
+    //   // if (timeBlock[i]) {
+    //   //   console.log(i.innerHTML);
     // }
   }
 }


### PR DESCRIPTION
This PR updates the setColor function to get the value of the innerHTML from each time block.  The innerHTML is then parsed to extract only the numerical value and remove the string of AM / PM.  It will be important to have  a numerical value to evaluate against the current time to map the colors correctly to the time blocks.