### PR TITLE
added conditional to evaluate morning hours

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -3,8 +3,7 @@
 // in the html.
 
 
-const currentDate = dayjs().format(`dddd D, YYYY`)
-
+const currentDate = dayjs().format(`dddd D, YYYY`);
 
 $(document).ready(function(){
 
@@ -18,10 +17,12 @@ $(document).ready(function(){
   
   // This dipslays the current time updated every second.  The seconds can be removed and the interval changed to a longer duration if seconds are not displayed.
   currentTime = () => {
-    let time = dayjs().format(`h:mm:ss`)
+    let time = dayjs().format(`h:mm:ss a`)
     $('#currentTime').text(time)
   }
   setInterval(currentTime, 1000)
+
+  setColors();
 
 })
 
@@ -46,10 +47,12 @@ $(function () {
   // TODO: Add code to display the current date in the header of the page.
 });
 
-setHour = () => {
-  let currentTime = parseInt(dayjs().format(`H`));
-  let amPm = dayjs().format(`a`)
 
+// This function is called within the setColors function and the return value is saved to the hourNow variable.
+setHour = () => {
+  let currentTime = parseInt(dayjs().format(`HH`));
+  let amPm = dayjs().format(`a`)
+  
   // This will evaluate false for all times after the 5pm time block and force the correct color.  The first else will return a value of the 12 or below during morning hours.
   if(amPm !== 'am' && currentTime >= 18) {
     return currentTime;
@@ -58,11 +61,14 @@ setHour = () => {
   } else {
     return currentTime -= 12;
   }
+
 }
 
+// This function is called within the document.ready function.
 setColors = () => {
   const timeBlocks = $('.hour')
-  
+  const amPm = dayjs().format(`a`)
+
   let hourNow = setHour();
   
   for (let i = 0; i < timeBlocks.length; i++) {
@@ -70,14 +76,39 @@ setColors = () => {
     let timeInt = parseInt(timeBlocks[i].innerHTML);
     console.log(timeInt)
     
-    if ((timeInt) < hourNow) {
-      timeBlocks[i].nextSibling.nextElementSibling.className += ' past'
-    } else if ((timeInt) === hourNow) {
+    if (timeInt > hourNow && amPm === 'am') {
+      timeBlocks[i].nextSibling.nextElementSibling.className += ' future'
+    } else if (timeInt > hourNow && amPm === 'pm') {
+        if (timeBlocks[i].className.includes('morning')) {
+          timeBlocks[i].nextSibling.nextElementSibling.className += ' past'
+        } else {
+          timeBlocks[i].nextSibling.nextElementSibling.className += ' future'
+        }
+    }
+      else if (timeInt === hourNow) {
       timeBlocks[i].nextSibling.nextElementSibling.className += ' present'
     } else {
-      timeBlocks[i].nextSibling.nextElementSibling.className += ' future'
+      timeBlocks[i].nextSibling.nextElementSibling.className += ' past'
     }
   }
 }
 
+// const morning = $('.morning')
+// const afternoon = $('.afternoon')
+
+// setMorning = () => {
+//   for (let i = 0; i < morning.length; i++) {
+//   morning[i].nextSibling.nextElementSibling.className += ' past'
+// }
+// }
+
+// setAfternoon = () => {
+//   for (let i = 0; i < morning.length; i++) {
+//     if (timeInt > hourNow) {
+//   afternoon[i].nextSibling.nextElementSibling.className += ' future'
+//   } else if (timeInt === hourNow) {
+//     afternoon[i].nextSibling.nextElementSibling.className += ' present'
+//   }
+// }
+// }
 

--- a/index.html
+++ b/index.html
@@ -42,8 +42,8 @@
         -->
 
       <!-- Example of a past time block. The "past" class adds a gray background color. -->
-      <div id="hour-9" class="row time-block past">
-        <div class="col-2 col-md-1 hour text-center py-3">9AM</div>
+      <div id="hour-9" class="row time-block">
+        <div class="col-2 col-md-1 hour text-center py-3 morning">9AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
@@ -51,8 +51,8 @@
       </div>
 
       <!-- Example of a a present time block. The "present" class adds a red background color. -->
-      <div id="hour-10" class="row time-block present">
-        <div class="col-2 col-md-1 hour text-center py-3">10AM</div>
+      <div id="hour-10" class="row time-block">
+        <div class="col-2 col-md-1 hour text-center py-3 morning">10AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
@@ -60,56 +60,56 @@
       </div>
 
       <!-- Example of a future time block. The "future" class adds a green background color. -->
-      <div id="hour-11" class="row time-block future">
-        <div class="col-2 col-md-1 hour text-center py-3">11AM</div>
+      <div id="hour-11" class="row time-block">
+        <div class="col-2 col-md-1 hour text-center py-3 morning">11AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
       </div>
 
-      <div id="hour-12" class="row time-block future">
-        <div class="col-2 col-md-1 hour text-center py-3">12PM</div>
+      <div id="hour-12" class="row time-block">
+        <div class="col-2 col-md-1 hour text-center py-3 morning">12PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
       </div>
 
-      <div id="hour-1" class="row time-block future">
-        <div class="col-2 col-md-1 hour text-center py-3">1PM</div>
+      <div id="hour-1" class="row time-block">
+        <div class="col-2 col-md-1 hour text-center py-3 afternoon">1PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
       </div>
 
-      <div id="hour-2" class="row time-block future">
-        <div class="col-2 col-md-1 hour text-center py-3">2PM</div>
+      <div id="hour-2" class="row time-block">
+        <div class="col-2 col-md-1 hour text-center py-3 afternoon">2PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
       </div>
 
-      <div id="hour-3" class="row time-block future">
-        <div class="col-2 col-md-1 hour text-center py-3">3PM</div>
+      <div id="hour-3" class="row time-block">
+        <div class="col-2 col-md-1 hour text-center py-3 afternoon">3PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
       </div>
 
-      <div id="hour-4" class="row time-block future">
-        <div class="col-2 col-md-1 hour text-center py-3">4PM</div>
+      <div id="hour-4" class="row time-block">
+        <div class="col-2 col-md-1 hour text-center py-3 afternoon">4PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
       </div>
 
-      <div id="hour-5" class="row time-block future">
-        <div class="col-2 col-md-1 hour text-center py-3">5PM</div>
+      <div id="hour-5" class="row time-block">
+        <div class="col-2 col-md-1 hour text-center py-3 afternoon">5PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>


### PR DESCRIPTION
This PR  creates additional classes of  morning and afternoon that were added to the text areas of each block in the index.html to help better evaluate the time and provide more options for conditional statements.  The initial example classes are also removed in this PR.

In the JavaScript file, a new variable, amPm, was introduced to help differentiate between morning and afternoon.  The current bug I'm working to resolve sees either the afternoon or morning evaluating incorrectly due to the comparison of the time used.  This issue would easily be resolved with 24 hour time values, but that does not feel like a viable solution since many users would not want 24 hour time values on their schedule.  The conditional statement is currently evaluating times correctly during the afternoon hours with the addition of an extra conditional statement that is noted in the script file.  More work is required to properly evaluate the afternoon colors in the morning hours.