### PR TITLE
added final conditional statement needed for noon hour

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -105,8 +105,14 @@ setColors = () => {
       timeBlocks[i].nextSibling.nextElementSibling.className += ' present'
     }
     else {
+      
+      // This staement was needed during the noon hour to fix a bug preventing afternoon hours from being evaluated as future due to the !=='pm'
+      if (timeBlocks[i].className.includes('afternoon') && hourNow < 18 && hourNow === 12) {
+        timeBlocks[i].nextSibling.nextElementSibling.className += ' future'
+      } 
+      
       // An additional statement was required here to catch afternoon hours that were evaluating as false on the first conditional statement and set them to future during morning hours.
-      if (timeBlocks[i].className.includes('afternoon') && hourNow < 18 && amPm !== 'pm') {
+      else if (timeBlocks[i].className.includes('afternoon') && hourNow < 18 && amPm !== 'pm') {
         timeBlocks[i].nextSibling.nextElementSibling.className += ' future'
       } else {
       timeBlocks[i].nextSibling.nextElementSibling.className += ' past'


### PR DESCRIPTION
This PR adds what should be the last conditional statement required for the application.  Testing revealed that afternoon hours were evaluating as false during the 12:00 pm time block.  This was due to all conditions being false and filtering down to the last else statement that sets time blocks to past when all other conditions are not met.  A conditional statement that includes hourNow === 12 was added to correct this bug during the specific time slot.